### PR TITLE
Exa to Eza

### DIFF
--- a/.config/fish/functions/ll.fish
+++ b/.config/fish/functions/ll.fish
@@ -1,3 +1,3 @@
 function ll
-  exa -l --all $argv
+  eza -l --all --icons $argv
 end

--- a/.zshrc
+++ b/.zshrc
@@ -100,7 +100,8 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
-alias ll='exa -l --all --group'
+alias ll='eza -l --all --group --icons'
+alias ls='eza --icons'
 alias cat='bat -P -p'
 alias vim="nvim"
 


### PR DESCRIPTION
[Exa](https://github.com/ogham/exa) has been deprecated for awhile apparently. [Eza](https://github.com/eza-community/eza) is maintained.